### PR TITLE
Enable selection of installed LuCI themes

### DIFF
--- a/usr/lib/lua/luci/model/cbi/admin_system/system.lua
+++ b/usr/lib/lua/luci/model/cbi/admin_system/system.lua
@@ -126,9 +126,9 @@ function o.write(self, section, value)
 	m.uci:set("luci", "main", "lang", value)
 end
 
-o = s:taboption("language", ListValue, "_theme", translate("Theme"))
 
-for k, v in luci.util.kspairs(conf.themes) do	
+o = s:taboption("language", ListValue, "_mediaurlbase", translate("Design"))
+for k, v in pairs(conf.themes) do
 	if k:sub(1, 1) ~= "." then
 		o:value(v, k)
 	end

--- a/usr/lib/lua/luci/model/cbi/admin_system/system.lua
+++ b/usr/lib/lua/luci/model/cbi/admin_system/system.lua
@@ -126,4 +126,20 @@ function o.write(self, section, value)
 	m.uci:set("luci", "main", "lang", value)
 end
 
+o = s:taboption("language", ListValue, "_theme", translate("Theme"))
+
+for k, v in luci.util.kspairs(conf.themes) do	
+	if k:sub(1, 1) ~= "." then
+		o:value(v, k)
+	end
+end
+
+function o.cfgvalue(...)
+	return m.uci:get("luci", "main", "mediaurlbase")
+end
+
+function o.write(self, section, value)
+	m.uci:set("luci", "main", "mediaurlbase", value)
+end
+
 return m


### PR DESCRIPTION
Coded installed theme display and selection based on investigations at http://itus.accessinnov.com/LuCI-Themes-tp435p662.html 

Later compared to system.lua within Cavium OpenWrt (not far off the mark!) and updated the label to match.
